### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/to_do_app/views.py
+++ b/to_do_app/views.py
@@ -192,8 +192,11 @@ class TaskViewSet(viewsets.ModelViewSet):
                 queryset = backend().filter_queryset(self.request, queryset, self)
             return queryset
         except Exception as e:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.error("An error occurred while filtering the queryset", exc_info=True)
             raise serializers.ValidationError({
-                'filter': f"Filter error: {str(e)}"
+                'filter': "An error occurred while processing the filters. Please try again later."
             })
 
     @action(detail=False, methods=['get'])


### PR DESCRIPTION
Potential fix for [https://github.com/Pwani-University-Tech/django_contributions/security/code-scanning/1](https://github.com/Pwani-University-Tech/django_contributions/security/code-scanning/1)

To fix the issue, we need to ensure that exception details, including stack traces, are not exposed to external users. Instead, we should log the exception details internally for debugging purposes and return a generic error message to the user. Specifically:
1. Replace the direct inclusion of `str(e)` in the error response with a generic error message.
2. Log the exception details (e.g., using Python's `logging` module) to ensure developers can still access the information for debugging.
3. Update the code on line 195 to implement these changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
